### PR TITLE
Various changes to make OpenDCD build successfully

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,15 @@
 gitrevision.cc
 compiler-version.cc
 compiler-flags.cc
+
+
+3rdparty/local/
+3rdparty/openfst-src.tar.gz
+3rdparty/openfst-src/
+src/bin/dcd-recog
+src/bin/far-to-lattice
+src/bin/farfilter
+src/bin/farprintnbeststrings
+src/kaldibin/lattice-to-far
+src/kaldibin/make-arc-types
+src/nbproject/

--- a/3rdparty/Makefile
+++ b/3rdparty/Makefile
@@ -32,8 +32,7 @@ openfst-src.tar.gz:
 openfst-src/Makefile: $(SRCDIR)
 	cd openfst-src/; ./configure --prefix=$(LOCAL) \
 	--enable-static --enable-bin --enable-compact-fsts --enable-const-fsts --enable-far \
-	--enable-linear-fsts --enable-lookahead-fsts --enable-ngram-fsts --enable-pdt --enable-bin \
-	CXXFLAGS=-stdlib=libstdc++
+	--enable-linear-fsts --enable-lookahead-fsts --enable-ngram-fsts --enable-pdt --enable-bin
 
 .PHONY: openfst # so target will be made even though "openfst" exists.
 

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ Quick Installation Guide
 -------------------------
 
 ````bash
+    export KALDI_ROOT=/path/to/kaldi-trunk/
     git clone https://github.com/opendcd/opendcd.git
-````
-
-````bash
-    cd src/bin
+    cd opendcd/3rdparty
+    make
+    cd ../src
     make
 ````
 

--- a/src/bin/Makefile
+++ b/src/bin/Makefile
@@ -34,7 +34,7 @@ dcd-recog-profile: dcd-recog.o parse-options.o text-utils.o log.o utils.o gitrev
 	memdebug.o compiler-version.o cpu-stats.o config.o feat-readers.o
 	$(CXX)  $^ -o $@  $(LDFLAGS) $(LDLIBS) -lfst -lfstfar
 
-dcd-recog.cc: ../include/dcd/arc-decoder.h
+# dcd-recog.cc: ../include/dcd/arc-decoder.h
 
 dcd-lex: dcdlex.o
 	$(CXX)  $^ -o $@  $(LDFLAGS) $(LDLIBS) -lfst -lfstfarscript

--- a/src/linux.mk
+++ b/src/linux.mk
@@ -7,7 +7,7 @@ TOP := $(dir $(lastword $(MAKEFILE_LIST)))
 CC=gcc
 CXX=g++
 DOTGITDIR+=../../.git
-CXXFLAGS+=-I../include/ -I../../3rdparty/openfst-src/include/ \
+CXXFLAGS+=-I../include/ -I../../3rdparty/local/include/ \
 					-Wno-sign-compare -Wno-dangling-else \
 					-Wno-deprecated-writable-strings -DOS_LINUX  -std=c++0x -g -O2
 CXXFLAGS+=-DMEMDEBUG


### PR DESCRIPTION
The current build instructions are incomplete and the Make files contain errors. The changes in this PR seem to enable OpenDCD to build successfully.
